### PR TITLE
Adapt selection of text style to be material3 compatible

### DIFF
--- a/lib/utils/my_alert_dialog.dart
+++ b/lib/utils/my_alert_dialog.dart
@@ -104,7 +104,7 @@ class MyAlertDialog<T> extends StatelessWidget {
             new EdgeInsets.fromLTRB(
                 24.0, 24.0, 24.0, isDividerEnabled ? 20.0 : 0.0),
         child: new DefaultTextStyle(
-          style: Theme.of(context).textTheme.headline6!,
+          style: Theme.of(context).textTheme.titleLarge!,
           child: new Semantics(child: title, namesRoute: true),
         ),
       ));
@@ -130,7 +130,7 @@ class MyAlertDialog<T> extends StatelessWidget {
         child: new Padding(
           padding: contentPadding,
           child: new DefaultTextStyle(
-            style: Theme.of(context).textTheme.subtitle1!,
+            style: Theme.of(context).textTheme.titleMedium!,
             child: content!,
           ),
         ),


### PR DESCRIPTION
Fixes compile-time errors with outdated text styles in flutter > 3.22