### PR TITLE
replace deprecated component

### DIFF
--- a/lib/utils/my_alert_dialog.dart
+++ b/lib/utils/my_alert_dialog.dart
@@ -62,11 +62,11 @@ class MyAlertDialog<T> extends StatelessWidget {
   ///
   /// Typically this is a list of [TextButton] widgets.
   ///
-  /// These widgets will be wrapped in a [ButtonBar], which introduces 8 pixels
+  /// These widgets will be wrapped in a [OverflowBar], which introduces 8 pixels
   /// of padding on each side.
   ///
   /// If the [title] is not null but the [content] _is_ null, then an extra 20
-  /// pixels of padding is added above the [ButtonBar] to separate the [title]
+  /// pixels of padding is added above the [OverflowBar] to separate the [title]
   /// from the [actions].
   final List<Widget>? actions;
 
@@ -140,7 +140,7 @@ class MyAlertDialog<T> extends StatelessWidget {
     if (actions != null) {
       if (isDividerEnabled) children.add(divider);
       children.add(
-        new ButtonBar(
+        new OverflowBar(
           children: actions!,
         ),
       );


### PR DESCRIPTION
As suggested by analyzer:
```
info • 'ButtonBar' is deprecated and shouldn't be used. Use OverflowBar instead. This feature was deprecated after v3.21.0-10.0.pre • lib/utils/my_alert_dialog.dart:65:43 • deprecated_member_use
   info • 'ButtonBar' is deprecated and shouldn't be used. Use OverflowBar instead. This feature was deprecated after v3.21.0-[10](https://github.com/atn832/language_picker/actions/runs/10667269040/job/29564471753?pr=14#step:5:11).0.pre • lib/utils/my_alert_dialog.dart:69:45 • deprecated_member_use
   info • 'ButtonBar' is deprecated and shouldn't be used. Use OverflowBar instead. This feature was deprecated after v3.21.0-10.0.pre • lib/utils/my_alert_dialog.dart:143:13 • deprecated_member_use
   info • 'ButtonBar.new' is deprecated and shouldn't be used. Use OverflowBar instead. This feature was deprecated after v3.21.0-10.0.pre • lib/utils/my_alert_dialog.dart:143:13 • deprecated_member_use
```
https://github.com/atn832/language_picker/actions/runs/10667269040/job/29564471753?pr=14#step:5:10